### PR TITLE
Load huge JavaScript file AFTER the page has rendered

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
     <title>SlimRoms</title>
     <meta name="description" content="SlimRoms' website, news, downloads.">
     <meta content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" name="viewport">
-    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
     <link rel="import" href="bower_components/core-drawer-panel/core-drawer-panel.html">
     <link rel="import" href="bower_components/core-animated-pages/core-animated-pages.html">
     <link rel="import" href="bower_components/core-animated-pages/transitions/cross-fade.html">
@@ -979,6 +978,8 @@
 
 
     <!-- JAVASCRIPT -->
+    
+    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
 
     <script>
         function switchPage(pagenum)


### PR DESCRIPTION
Loading large JavaScript files before the rest of the page is terrible practice as it causes very noticeable page load delays while the JavaScript runs. This has been evident on slimroms.eu for quite a while now.
